### PR TITLE
Add an .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,20 @@
+# Ignore files with sensitive environment variables
+.env
+.env.test
+
+# Next.js output
+.next/
+
+# Parcel cache
+.cache/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage directory used by tools like istanbul
+.nyc_output
+coverage


### PR DESCRIPTION
Without a .npmignore, npm will use the .gitignore to ignore what to not
publish (https://docs.npmjs.com/misc/developers)
including the `dist` folder (https://stackoverflow.com/a/31642553/58997)