### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
+  - '12'
   - '10'
-  - '8'
 
 script:
 - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 - npm test
 
 install:
-  - npm i -g npm@6.0.1
+  - npm i -g npm@6.14.2
   - npm ci
   - npm run build
 


### PR DESCRIPTION
Drop Node v8 because it is out of LTS, and it blocks using a newer version of jsdom (See https://github.com/retest/recheck-web-js/pull/22). Additionally bump the version of npm to that is available right now.