### PR TITLE
Sync with changes made to Javascript in recheck-web

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -171,19 +171,19 @@ export function addCoordinates(attributes: ExportedAttributes, node: Element): v
   // these attributes need special treatment
   attributes['absolute-x'] = getX(node);
   attributes['absolute-y'] = getY(node);
-  attributes['absolute-width'] = node.getBoundingClientRect().width;
-  attributes['absolute-height'] = node.getBoundingClientRect().height;
+  attributes['absolute-width'] = getWidth(node);
+  attributes['absolute-height'] = getHeight(node);
   const parentNode = node.parentNode as Element;
   if (typeof parentNode.getBoundingClientRect === 'function') {
     attributes['x'] = getX(node) - getX(parentNode);
     attributes['y'] = getY(node) - getY(parentNode);
-    attributes['width'] = node.getBoundingClientRect().width - parentNode.getBoundingClientRect().width;
-    attributes['height'] = node.getBoundingClientRect().height - parentNode.getBoundingClientRect().height;
+    attributes['width'] = getWidth(node) - getWidth(parentNode);
+    attributes['height'] = getHeight(node) - getHeight(parentNode);
   } else {
     attributes['x'] = getX(node);
     attributes['y'] = getY(node);
-    attributes['width'] = node.getBoundingClientRect().width;
-    attributes['height'] = node.getBoundingClientRect().height;
+    attributes['width'] = getWidth(node);
+    attributes['height'] = getHeight(node);
   }
 }
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -97,7 +97,9 @@ export function transform(node: any): { [key: string]: any } {
   for (let i = 0; i < attrs.length; i++) {
     const attributeName = attrs[i].name;
     const attributeValue = attrs[i].value;
-    extractedAttributes[attributeName] = attributeValue;
+    if (attributeValue != undefined && attributeValue != '' && attributeValue != 'null') {
+      extractedAttributes[attributeName] = attributeValue;
+    }
   }
   // overwrite empty attributes (e.g. 'disabled')
   extractedAttributes['checked'] = node.checked;

--- a/src/script.ts
+++ b/src/script.ts
@@ -153,6 +153,20 @@ export function getY(node: Element): number {
   return rect.top + window.scrollY;
 }
 
+export function getWidth(node: Element): number {
+  if (node.getBoundingClientRect().width) {
+    return node.getBoundingClientRect().width;
+  }
+  return node.clientWidth;
+}
+
+export function getHeight(node: Element): number {
+  if (node.getBoundingClientRect().height) {
+    return node.getBoundingClientRect().height;
+  }
+  return node.clientHeight;
+}
+
 export function addCoordinates(attributes: ExportedAttributes, node: Element): void {
   // these attributes need special treatment
   attributes['absolute-x'] = getX(node);

--- a/src/script.ts
+++ b/src/script.ts
@@ -130,11 +130,23 @@ export function getText(node: Node): string | null {
 
 export function getX(node: Element): number {
   const rect = node.getBoundingClientRect();
+
+  // Internet Explorer does not support scrollX, but provides the non-standard pageXOffset
+  if (window.scrollX === undefined && window.pageXOffset) {
+    return rect.left + window.pageXOffset;
+  }
+
   return rect.left + window.scrollX;
 }
 
 export function getY(node: Element): number {
   const rect = node.getBoundingClientRect();
+
+  // Internet Explorer does not support scrollY, but provides the non-standard pageYOffset
+  if (window.scrollY === undefined && window.pageYOffset) {
+    return rect.top + window.pageYOffset;
+  }
+
   return rect.top + window.scrollY;
 }
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -86,6 +86,7 @@ export function transform(node: any): { [key: string]: any } {
     value: node.value as string,
     tabindex: node.tabIndex as number,
     shown: isShown(node) as boolean,
+    covered: isCovered(node) as boolean,
   };
   if (node.nodeType === node.TEXT_NODE) {
     addCoordinates(extractedAttributes, node.parentNode as Element);
@@ -181,6 +182,34 @@ export function isDisabled(node: any): boolean {
     return true;
   }
   return node.disabled ? true : false;
+}
+
+// check if element is behind another one
+export function isCovered(node: any): boolean {
+  const BOUNDING_PRECISION = 2;
+
+  // TODO Handle false negatives for elements outside of viewport
+  if (typeof node.getBoundingClientRect === 'function' && document.elementFromPoint != undefined) {
+    const boundingRect = node.getBoundingClientRect();
+
+    const boundingLeft = boundingRect.left + BOUNDING_PRECISION;
+    const boundingRight = boundingRect.right - BOUNDING_PRECISION;
+    const boundingTop = boundingRect.top + BOUNDING_PRECISION;
+    const boundingBottom = boundingRect.bottom - BOUNDING_PRECISION;
+
+    const topLeft = document.elementFromPoint(boundingLeft, boundingTop);
+    const topRight = document.elementFromPoint(boundingRight, boundingTop);
+    const bottomLeft = document.elementFromPoint(boundingLeft, boundingBottom);
+    const bottomRight = document.elementFromPoint(boundingRight, boundingBottom);
+    if ((topLeft != null && !node.contains(topLeft))
+      || (topRight != null && !node.contains(topRight))
+      || (bottomLeft != null && !node.contains(bottomLeft))
+      || (bottomRight != null && !node.contains(bottomRight))) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 //extract *given* CSS style attributes

--- a/src/script.ts
+++ b/src/script.ts
@@ -84,7 +84,7 @@ export function transform(node: any): { [key: string]: any } {
     tagName: node.tagName.toLowerCase() as string,
     text: getText(node) as string,
     value: node.value as string,
-    'tab-index': node.tabIndex as number,
+    tabindex: node.tabIndex as number,
     shown: isShown(node) as boolean,
   };
   if (node.nodeType === node.TEXT_NODE) {


### PR DESCRIPTION
I compared the functions present in the current release of recheck-web-js (`script.js`) with what is present in (`getAllElementsByPath.js`) on recheck-web. I transferred all meaningful changes over, and kept some improvements (like additional null checks) on the other side.

Notice that I adapted the fix for IE compatibility ("Provide IE compatibility for getX/getY") to also fall back and use IE's `pageXOffset` and `pageYOffset`. The original method in recheck-web did not do this and just returned the value of `rect.left` or `rect.top`.

Also notice that `isCovered()` will return false if `elementFromPoint` is undefined. This is mostly done in order to make the tests work, as jsdom will not support this function.

## State of the PR

All done.